### PR TITLE
feat: implementar filtros con selector de fechas en cupos

### DIFF
--- a/src/components/mobile/cupos/CuposMobile.tsx
+++ b/src/components/mobile/cupos/CuposMobile.tsx
@@ -1,5 +1,5 @@
 // CuposMobile.tsx
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useContext } from "react";
 import {
   Box,
   Typography,
@@ -8,16 +8,33 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
+  Checkbox,
+  Button,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
 } from "@mui/material";
 import ClearSharpIcon from "@mui/icons-material/ClearSharp";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import CancelIcon from "@mui/icons-material/Cancel";
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import FilterListIcon from '@mui/icons-material/FilterList';
 import { TarjetaCupos } from "../../cargas/cupos/TarjetaCupos";
 import { CreadorCupos } from "../../cargas/creadores/CreadorCupos";
 import TurnoForm from "../../forms/turnos/TurnoForm";
 import TurnoConErroresForm from "../../forms/turnos/tabs/turnosConErrores/TurnoConErroresForm";
 import CardMobile from "../../cards/mobile/CardMobile";
+import { ContextoGeneral } from "../../Contexto";
+import dayjs, { Dayjs } from 'dayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { PickersDay } from '@mui/x-date-pickers/PickersDay';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import MainButton from '../../botones/MainButtom';
 
 interface Turno {
   id?: number;
@@ -33,6 +50,30 @@ interface Cupo {
   turnosConErrores?: any[]; // propiedad opcional para errores
 }
 
+interface FiltrosCupos {
+  excluirPagados: boolean;
+  mostrarVaciosDelPasado: boolean;
+  fechaDesde?: string;
+  fechaHasta?: string;
+}
+
+// Componente para customizar el color del día seleccionado
+const CustomDay = (props: any) => {
+  const { selected } = props;
+  const { theme } = useContext(ContextoGeneral);
+  return (
+    <PickersDay
+      {...props}
+      sx={selected ? {
+        backgroundColor: `${theme.colores.azul} !important`,
+        color: '#fff',
+        fontWeight: 'bold',
+        borderRadius: '50%',
+      } : {}}
+    />
+  );
+};
+
 interface CuposMobileProps {
   cupos: Cupo[];
   estadoCarga: string;
@@ -41,6 +82,8 @@ interface CuposMobileProps {
   theme: any;
   fields: string[];
   headerNames: string[];
+  filtros: FiltrosCupos;
+  setFiltros: (filtros: FiltrosCupos) => void;
 }
 
 export default function CuposMobile({
@@ -51,7 +94,11 @@ export default function CuposMobile({
   theme,
   fields,
   headerNames,
+  filtros,
+  setFiltros,
 }: CuposMobileProps) {
+  const { theme: contextTheme } = useContext(ContextoGeneral);
+  
   const [expandedCard, setExpandedCard] = useState<number | null>(null);
   const [openDialogCupo, setOpenDialogCupo] = useState(false);
   const [openDialogTurno, setOpenDialogTurno] = useState(false);
@@ -62,9 +109,24 @@ export default function CuposMobile({
   const [openDialogError, setOpenDialogError] = useState(false);
   const [selectedError, setSelectedError] = useState<any>(null);
 
+  // Estados para el selector de fechas
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [calendarMode, setCalendarMode] = useState<'start' | 'end'>('start');
+  const [customStart, setCustomStart] = useState<Dayjs>(dayjs().subtract(7, 'day'));
+  const [customEnd, setCustomEnd] = useState<Dayjs>(dayjs());
+
+  // Estado para el menú de filtros
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
   const availableDates = Array.from(new Set(cupos?.map((c) => c.fecha)));
   const [selectedDate, setSelectedDate] = useState<string>(availableDates[0] || "");
   const [filteredCupos, setFilteredCupos] = useState<Cupo[]>([]);
+
+  // Ejecutar refresh cuando cambien los filtros
+  useEffect(() => {
+    refreshCupos();
+  }, [filtros, refreshCupos]);
 
   useEffect(() => {
     if (selectedDate) {
@@ -105,6 +167,51 @@ export default function CuposMobile({
     if (dateScrollRef.current) {
       dateScrollRef.current.scrollBy({ left: 120, behavior: "smooth" });
     }
+  };
+
+  // Función para validar que el rango no exceda 2 meses
+  const validarRangoFechas = (start: Dayjs, end: Dayjs): boolean => {
+    const diffInMonths = end.diff(start, 'month', true);
+    return diffInMonths <= 2;
+  };
+
+  // Handler para cambio de filtros
+  const handleFiltroChange = (filtro: keyof FiltrosCupos) => {
+    setFiltros({
+      ...filtros,
+      [filtro]: !filtros[filtro],
+    });
+  };
+
+  // Handler para aplicar rango de fechas
+  const handleAplicarRangoFechas = () => {
+    if (!validarRangoFechas(customStart, customEnd)) {
+      alert('El rango de fechas no puede exceder 2 meses');
+      return;
+    }
+    
+    setFiltros({
+      ...filtros,
+      fechaDesde: customStart.format('YYYY-MM-DD'),
+      fechaHasta: customEnd.format('YYYY-MM-DD'),
+    });
+    setShowDatePicker(false);
+  };
+
+  // Handlers para el menú de filtros
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleOpenDatePicker = () => {
+    setShowDatePicker(true);
+    setCustomStart(dayjs(filtros.fechaDesde));
+    setCustomEnd(dayjs(filtros.fechaHasta));
+    handleClose();
   };
 
   const renderDateChips = () => (
@@ -179,9 +286,77 @@ export default function CuposMobile({
 
   return (
     <Box padding={2}>
-      <Typography variant="h5" gutterBottom>
-        Cupos
-      </Typography>
+      {/* Header con título y menú de filtros */}
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="h5" gutterBottom sx={{ mb: 0 }}>
+          Cupos
+        </Typography>
+        <IconButton
+          onClick={handleClick}
+          sx={{ color: contextTheme.colores.azul }}
+        >
+          <MoreVertIcon />
+        </IconButton>
+      </Box>
+
+      {/* Menú desplegable de filtros */}
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        PaperProps={{
+          sx: {
+            minWidth: 250,
+            mt: 1,
+          },
+        }}
+      >
+        <MenuItem onClick={handleClose} disabled>
+          <ListItemIcon>
+            <FilterListIcon />
+          </ListItemIcon>
+          <ListItemText primary="Filtros" />
+        </MenuItem>
+        <MenuItem onClick={() => {
+          handleFiltroChange('excluirPagados');
+          handleClose();
+        }}>
+          <Checkbox
+            checked={filtros.excluirPagados}
+            sx={{
+              color: contextTheme.colores.azul,
+              '&.Mui-checked': {
+                color: contextTheme.colores.azul,
+              },
+            }}
+          />
+          <ListItemText primary="Excluir cupos pagados" />
+        </MenuItem>
+        <MenuItem onClick={() => {
+          handleFiltroChange('mostrarVaciosDelPasado');
+          handleClose();
+        }}>
+          <Checkbox
+            checked={filtros.mostrarVaciosDelPasado}
+            sx={{
+              color: contextTheme.colores.azul,
+              '&.Mui-checked': {
+                color: contextTheme.colores.azul,
+              },
+            }}
+          />
+          <ListItemText primary="Mostrar cupos vacíos del pasado" />
+        </MenuItem>
+        <MenuItem onClick={handleOpenDatePicker}>
+          <ListItemIcon>
+            <CalendarMonthIcon />
+          </ListItemIcon>
+          <ListItemText 
+            primary="Rango de fechas" 
+            secondary={`${filtros.fechaDesde} - ${filtros.fechaHasta}`}
+          />
+        </MenuItem>
+      </Menu>
 
       {estadoCarga === "Cargando" && (
         <Box
@@ -338,6 +513,97 @@ export default function CuposMobile({
             idCarga={idCarga}
           />
         </DialogContent>
+      </Dialog>
+
+      {/* Diálogo para selector de fechas */}
+      <Dialog open={showDatePicker} onClose={() => setShowDatePicker(false)}>
+        <DialogTitle>Seleccionar rango de fechas (máximo 2 meses)</DialogTitle>
+        <DialogContent>
+          <Box display="flex" gap={2} alignItems="center" mt={1} justifyContent="center">
+            <Box>
+              <Typography variant="body2">Desde</Typography>
+              <Button
+                variant={calendarMode === 'start' ? 'contained' : 'outlined'}
+                onClick={() => setCalendarMode('start')}
+                sx={{ mb: 1, minWidth: 120, color: calendarMode === 'start' ? '#fff' : contextTheme.colores.azul, backgroundColor: calendarMode === 'start' ? contextTheme.colores.azul : 'transparent', borderColor: contextTheme.colores.azul }}
+              >
+                {customStart.format('DD/MM/YYYY')}
+              </Button>
+            </Box>
+            <Box>
+              <Typography variant="body2">Hasta</Typography>
+              <Button
+                variant={calendarMode === 'end' ? 'contained' : 'outlined'}
+                onClick={() => setCalendarMode('end')}
+                sx={{ mb: 1, minWidth: 120, color: calendarMode === 'end' ? '#fff' : contextTheme.colores.azul, backgroundColor: calendarMode === 'end' ? contextTheme.colores.azul : 'transparent', borderColor: contextTheme.colores.azul }}
+              >
+                {customEnd.format('DD/MM/YYYY')}
+              </Button>
+            </Box>
+          </Box>
+          <ThemeProvider theme={createTheme({
+            palette: {
+              primary: {
+                main: contextTheme.colores.azul,
+              },
+            },
+          })}>
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+              <DateCalendar
+                value={calendarMode === 'start' ? customStart : customEnd}
+                minDate={calendarMode === 'end' ? customStart : undefined}
+                maxDate={calendarMode === 'start' ? customEnd : dayjs()}
+                onChange={(date) => {
+                  if (!date) return;
+                  if (calendarMode === 'start') {
+                    setCustomStart(date);
+                    if (date.isAfter(customEnd)) setCustomEnd(date);
+                  } else {
+                    setCustomEnd(date);
+                    if (date.isBefore(customStart)) setCustomStart(date);
+                  }
+                }}
+                slots={{
+                  day: (dayProps) => (
+                    <CustomDay
+                      {...dayProps}
+                      selected={
+                        (calendarMode === 'start' && dayProps.day.isSame(customStart, 'day')) ||
+                        (calendarMode === 'end' && dayProps.day.isSame(customEnd, 'day'))
+                      }
+                    />
+                  ),
+                }}
+              />
+            </LocalizationProvider>
+          </ThemeProvider>
+          {!validarRangoFechas(customStart, customEnd) && (
+            <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+              El rango de fechas no puede exceder 2 meses
+            </Typography>
+          )}
+        </DialogContent>
+        <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2, px: 3, pb: 2 }}>
+          <MainButton
+            onClick={() => setShowDatePicker(false)}
+            text="Cancelar"
+            backgroundColor="transparent"
+            textColor={contextTheme.colores.azul}
+            borderRadius="8px"
+            hoverBackgroundColor="rgba(22, 54, 96, 0.1)"
+            divWidth="auto"
+          />
+          <MainButton
+            onClick={handleAplicarRangoFechas}
+            text="Aplicar"
+            backgroundColor={contextTheme.colores.azul}
+            textColor="#fff"
+            borderRadius="8px"
+            hoverBackgroundColor={contextTheme.colores.azulOscuro}
+            divWidth="auto"
+            disabled={customStart.isAfter(customEnd) || !validarRangoFechas(customStart, customEnd)}
+          />
+        </Box>
       </Dialog>
     </Box>
   );


### PR DESCRIPTION
- Reemplazar checkbox 'traerTodosDelPasado' por selector de fechas tipo calendario
- Limitar rango máximo a 2 meses para evitar sobrecarga del backend
- Agregar filtros en versión mobile con menú desplegable (3 puntos)
- Conectar filtros con refreshCupos para ejecutar GET automáticamente
- Usar color azul del theme en checkboxes y selector de fechas
- Implementar validación en tiempo real para rango de fechas