### PR TITLE
feat: optimizar permisos y vista de turnos para logística

### DIFF
--- a/src/components/cards/mobile/CardMobile.tsx
+++ b/src/components/cards/mobile/CardMobile.tsx
@@ -17,7 +17,7 @@ import { getExplicacionEstado } from './explicacionTurnos';
 import { useAllowed } from '../../hooks/auth/useAllowed';
 import EstadoTurnoForm from '../../forms/turnos/tabs/EstadoTurnoForm';
 import { useAuth } from '../../autenticacion/ContextoAuth';
-import { puedeVerEstado } from '../../../utils/turnoEstadoPermisos';
+import { puedeVerEstado, puedeEditarEstado } from '../../../utils/turnoEstadoPermisos';
 import InfoTooltip from '../../InfoTooltip';
 import NoteAltOutlinedIcon from '@mui/icons-material/NoteAltOutlined';
 import Popover from '@mui/material/Popover';
@@ -88,6 +88,10 @@ const CardMobile: React.FC<CardMobileProps> = ({
     if (ocultarBotonesAccion) return null;
     const estado = manejoTurnos.turnoLocal.estado?.nombre?.toLowerCase();
     if (estado === 'pagado') return null;
+    
+    // Verificar si el usuario puede editar este estado específico
+    const puedeEditar = manejoTurnos.turnoLocal.estado?.id && rolId ? puedeEditarEstado(manejoTurnos.turnoLocal.estado.id, rolId) : false;
+    
     const mainButton = (props: any) => (
       <Button
         variant="contained"
@@ -114,6 +118,36 @@ const CardMobile: React.FC<CardMobileProps> = ({
         console.error('No se puede abrir el diálogo, turno sin id:', item);
       }
     };
+    
+    // Si no puede editar, no mostrar botones de acción
+    if (!puedeEditar) {
+      return (
+        <Box sx={{ width: '100%', mt: 2, display: 'flex', flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'flex-start' }}>
+          <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+              No tienes permisos para editar turnos en estado "{manejoTurnos.turnoLocal.estado?.nombre}"
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', minWidth: 48 }}>
+            {/* Ícono de nota siempre disponible */}
+            <Tooltip title={manejoTurnos.turnoLocal.nota ? 'Ver/Editar nota' : 'Agregar nota'}>
+              <IconButton
+                sx={{ color: manejoTurnos.turnoLocal.nota ? theme.colores.azul : '#bdbdbd', mt: 1 }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setAnchorElNota(e.currentTarget);
+                  setNotaLocal(manejoTurnos.turnoLocal.nota || '');
+                }}
+                aria-label="nota turno"
+              >
+                <NoteAltOutlinedIcon fontSize="medium" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+      );
+    }
+    
     switch (estado) {
       case 'con errores':
         botones = <>{mainButton({ children: 'Corregir', onClick: () => safeOpenDialog('corregir') })}</>;

--- a/src/components/cargas/cupos/tabsCupos/CuposGridContainer.tsx
+++ b/src/components/cargas/cupos/tabsCupos/CuposGridContainer.tsx
@@ -30,6 +30,7 @@ import FilterListIcon from '@mui/icons-material/FilterList';
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import { ContextoGeneral } from '../../../Contexto';
+import { useAuth } from '../../../autenticacion/ContextoAuth';
 import CancelIcon from '@mui/icons-material/Cancel';
 
 interface Turno {
@@ -68,6 +69,7 @@ const fields = [
   "colaborador.apellido",
   "colaborador.cuil",
   "empresa.cuit",
+  "empresa.razonSocial",
   "camion.patente",
   "acoplado.patente",
   "acopladoExtra.patente",
@@ -85,6 +87,7 @@ const headerNames = [
   "Apellido",
   "CUIL Chofer",
   "CUIT Empresa",
+  "Razon Social",
   "Patente Camión",
   "Patente Acoplado",
   "Patente Acoplado Extra",
@@ -105,13 +108,41 @@ export const CuposGridContainer: React.FC<CuposGridContainerProps & { estadoCarg
   const [openDialog, setOpenDialog] = useState(false);
   const [selectedTurno, setSelectedTurno] = useState<any>(null);
   const { theme } = useContext(ContextoGeneral);
-  // Columnas seleccionadas para mostrar (por defecto las más relevantes)
-  const [selectedColumns, setSelectedColumns] = useState([
-    // "estado.nombre", // Estado NO seleccionado por defecto
+  const { user } = useAuth();
+  const rolId = user?.rol?.id;
+  
+  // Columnas específicas para logística (incluyendo estado pero no seleccionada por defecto)
+  const columnasLogistica = [
+    "colaborador.nombre",
+    "colaborador.apellido", 
+    "colaborador.cuil",
+    "empresa.cuit",
+    "empresa.razonSocial",
+    "camion.patente",
+    "acoplado.patente",
+    "acopladoExtra.patente",
+    "estado.nombre"
+  ];
+  
+  // Columnas por defecto para logística (sin estado)
+  const columnasLogisticaPorDefecto = [
+    "colaborador.nombre",
+    "colaborador.apellido", 
+    "colaborador.cuil",
+    "empresa.cuit",
+    "empresa.razonSocial",
+    "camion.patente",
+    "acoplado.patente",
+    "acopladoExtra.patente"
+  ];
+  
+  // Columnas por defecto para otros roles
+  const columnasPorDefecto = [
     "colaborador.nombre",
     "colaborador.apellido",
     "colaborador.cuil",
     "empresa.cuit",
+    "empresa.razonSocial",
     "camion.patente",
     "acoplado.patente",
     "acopladoExtra.patente",
@@ -122,7 +153,12 @@ export const CuposGridContainer: React.FC<CuposGridContainerProps & { estadoCarg
     "precioGrano",
     "factura",
     "numeroOrdenPago",
-  ]);
+  ];
+  
+  // Columnas seleccionadas para mostrar (por defecto las más relevantes)
+  const [selectedColumns, setSelectedColumns] = useState(
+    rolId === 4 ? columnasLogisticaPorDefecto : columnasPorDefecto
+  );
   const [anchorElColumns, setAnchorElColumns] = useState<null | HTMLElement>(null);
   const [openFilterDialog, setOpenFilterDialog] = useState(false);
   // Para exportar varias tablas
@@ -269,40 +305,47 @@ export const CuposGridContainer: React.FC<CuposGridContainerProps & { estadoCarg
       </Box>
       {/* Menú de columnas */}
       <Menu anchorEl={anchorElColumns} open={Boolean(anchorElColumns)} onClose={handleCloseColumns}>
-        {fields.map((field, idx) => (
-          <MenuItem key={field} onClick={() => handleToggleColumn(field)}
-            sx={{
-              color: theme.colores.azul,
-              borderRadius: '8px',
-              '&.Mui-selected, &:hover': {
-                backgroundColor: theme.colores.azul,
-                color: '#fff',
-              },
-            }}
-          >
-            <Checkbox
-              checked={selectedColumns.includes(field)}
+        {fields.map((field, idx) => {
+          // Si es logística, solo mostrar las columnas disponibles para ese rol
+          if (rolId === 4 && !columnasLogistica.includes(field)) {
+            return null;
+          }
+          
+          return (
+            <MenuItem key={field} onClick={() => handleToggleColumn(field)}
               sx={{
                 color: theme.colores.azul,
-                '&.Mui-checked': {
-                  color: theme.colores.azul,
-                },
-                '& .MuiSvgIcon-root': {
-                  borderColor: theme.colores.azul,
+                borderRadius: '8px',
+                '&.Mui-selected, &:hover': {
+                  backgroundColor: theme.colores.azul,
+                  color: '#fff',
                 },
               }}
-            />
-            <ListItemText primary={headerNames[idx]} />
-          </MenuItem>
-        ))}
+            >
+              <Checkbox
+                checked={selectedColumns.includes(field)}
+                sx={{
+                  color: theme.colores.azul,
+                  '&.Mui-checked': {
+                    color: theme.colores.azul,
+                  },
+                  '& .MuiSvgIcon-root': {
+                    borderColor: theme.colores.azul,
+                  },
+                }}
+              />
+              <ListItemText primary={headerNames[idx]} />
+            </MenuItem>
+          );
+        })}
       </Menu>
       {/* Diálogo de filtro */}
       <FilterDialog
         open={openFilterDialog}
         onClose={handleCloseFilter}
         onApplyFilter={handleApplyFilter}
-        columns={fields}
-        headerNames={headerNames}
+        columns={rolId === 4 ? columnasLogistica : fields}
+        headerNames={rolId === 4 ? columnasLogistica.map(f => headerNames[fields.indexOf(f)]) : headerNames}
         onUndoFilter={handleUndoFilter}
       />
       {/* Diálogo de exportar varias tablas */}

--- a/src/components/cargas/cupos/tabsCupos/TurnoGridRow.tsx
+++ b/src/components/cargas/cupos/tabsCupos/TurnoGridRow.tsx
@@ -10,7 +10,7 @@ import { getExplicacionEstado } from '../../../cards/mobile/explicacionTurnos';
 import { useAllowed } from '../../../hooks/auth/useAllowed';
 import EstadoTurnoForm from '../../../forms/turnos/tabs/EstadoTurnoForm';
 import { useAuth } from '../../../autenticacion/ContextoAuth';
-import { puedeVerEstado } from '../../../../utils/turnoEstadoPermisos';
+import { puedeVerEstado, puedeEditarEstado } from '../../../../utils/turnoEstadoPermisos';
 import Tooltip from '@mui/material/Tooltip';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -47,6 +47,10 @@ const TurnoGridRow: React.FC<TurnoGridRowProps> = ({ turno, cupo, refreshCupos, 
   const renderButtons = () => {
     const estado = manejoTurnos.turnoLocal.estado?.nombre?.toLowerCase();
     if (estado === 'pagado') return null;
+    
+    // Verificar si el usuario puede editar este estado específico
+    const puedeEditar = manejoTurnos.turnoLocal.estado?.id && rolId ? puedeEditarEstado(manejoTurnos.turnoLocal.estado.id, rolId) : false;
+    
     const mainButton = (props: any) => {
       const { key, ...rest } = props;
       return (
@@ -72,6 +76,29 @@ const TurnoGridRow: React.FC<TurnoGridRowProps> = ({ turno, cupo, refreshCupos, 
         />
       );
     };
+    
+    // Si no puede editar, no mostrar botones de acción
+    if (!puedeEditar) {
+      return (
+        <Box sx={{ display: 'flex', flexDirection: 'row', gap: 1, alignItems: 'center' }}>
+          <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic', fontSize: '0.75rem' }}>
+            Sin permisos para editar
+          </Typography>
+          {/* Ícono de nota siempre disponible */}
+          <Tooltip title={manejoTurnos.turnoLocal.nota ? 'Ver/Editar nota' : 'Agregar nota'}>
+            <IconButton
+              sx={{ color: manejoTurnos.turnoLocal.nota ? theme.colores.azul : '#bdbdbd' }}
+              onClick={e => manejoTurnos.handleOpenNota(e, manejoTurnos.turnoLocal.nota)}
+              aria-label="nota turno"
+              size="small"
+            >
+              <NoteAltOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      );
+    }
+    
     let botones: React.ReactNode[] = [];
     const safeOpenDialog = (dialog: null | 'corregir' | 'autorizar' | 'tara' | 'cartaPorte' | 'cargarCarta' | 'pesaje' | 'pago' | 'datospago' | 'factura' | 'adelanto') => {
       if (turno && turno.id) {

--- a/src/components/docstext/manual-logistica.md
+++ b/src/components/docstext/manual-logistica.md
@@ -79,7 +79,7 @@ La gestión de cupos y turnos es fundamental para organizar la logística de cad
 - **Editar cupo:** En la tarjeta o tabla, hacé clic en "Ver más" o el lápiz.
 - **Eliminar cupo:** Ícono de basurita. El sistema pedirá confirmación.
 - **Crear turno:** En la tarjeta del cupo, botón "Crear turno".
-- **Gestionar turnos:** Según el estado, podés corregir, validar, autorizar, cargar tara, cargar peso bruto, cargar carta de porte, cargar factura, pagar, etc. Logística puede operar sobre turnos en estado "Con errores" y "Validado".
+- **Gestionar turnos:** Según el estado, podés corregir, validar, autorizar, cargar tara, cargar peso bruto, cargar carta de porte, cargar factura, pagar, etc. **Puedes ver todos los turnos, pero solo puedes editar turnos en estado "Con errores" y "Validado"**.
 - **Filtrar y exportar:** Usá los botones para aplicar filtros avanzados o exportar la lista.
 - **Personalizar columnas:** Elegí qué datos ver en la tabla.
 
@@ -330,7 +330,8 @@ Permite estimar tarifas y costos de transporte.
 # Permisos y advertencias
 
 - Logística puede ver, crear y editar en casi todas las pantallas, pero **no puede eliminar** cargas, colaboradores, empresas, camiones, ubicaciones, contratos ni inconvenientes.
-- Puede corregir turnos con error y operar sobre turnos en estado "Con errores" y "Validado".
+- **Puede ver todos los turnos sin importar su estado**, pero **solo puede editar turnos en estado "Con errores" y "Validado"**.
+- Puede corregir turnos con error y crear/editar cupos y cargas, pero no eliminarlas.
 - No tiene acceso a usuarios ni dashboard.
 - Si no ves una opción, revisá tus permisos.
 - No borres datos críticos sin revisar dependencias.

--- a/src/components/helpbot/documentacion/permisos.json
+++ b/src/components/helpbot/documentacion/permisos.json
@@ -25,7 +25,7 @@
     "pantallas": {
       "Cargas": ["ver", "crear", "editar"],
       "Cupos": ["ver", "crear", "editar", "eliminar", "corregir turnos con error"],
-      "Turnos": ["ver", "crear", "editar", "eliminar", "operar sobre estados: Con errores, Validado"],
+      "Turnos": ["ver todos", "crear", "editar solo estados: Con errores, Validado", "eliminar", "operar sobre estados: Con errores, Validado"],
       "Usuarios": [],
       "Colaboradores": ["ver", "crear", "editar"],
       "Empresas": ["ver", "crear", "editar"],
@@ -38,7 +38,8 @@
       "Dashboard": []
     },
     "notas": [
-      "Logística puede operar sobre turnos en estado 'Con errores' y 'Validado'.",
+      "Logística puede ver todos los turnos sin importar su estado.",
+      "Solo puede editar turnos en estado 'Con errores' y 'Validado'.",
       "Puede corregir turnos con errores y crear/editar cupos y cargas, pero no eliminarlas.",
       "No puede eliminar cargas, colaboradores, empresas, camiones, ubicaciones ni inconvenientes.",
       "No tiene acceso a usuarios ni dashboard."

--- a/src/components/helpbot/system messages/permisos/permisos_logistica.md
+++ b/src/components/helpbot/system messages/permisos/permisos_logistica.md
@@ -4,7 +4,7 @@
 |--------------|-----|-------|--------|--------|------------------------------------|
 | Cargas       | ✔   | ✔     | ✔      | -      | No puede eliminar cargas           |
 | Cupos        | ✔   | ✔     | ✔      | ✔      | Puede corregir turnos con error    |
-| Turnos       | ✔   | ✔     | ✔      | ✔      | Solo puede operar sobre estados: Con errores, Validado. No puede cambiar estado libremente. |
+| Turnos       | ✔   | ✔     | ✔      | ✔      | Puede ver todos los turnos, pero solo puede editar turnos en estados: Con errores, Validado. No puede cambiar estado libremente. |
 | Usuarios     | -   | -     | -      | -      | No tiene acceso                    |
 | Colaboradores| ✔   | ✔     | ✔      | -      | No puede eliminar colaboradores    |
 | Empresas     | ✔   | ✔     | ✔      | -      | No puede eliminar empresas         |
@@ -17,5 +17,6 @@
 | Dashboard    | -   | -     | -      | -      | No tiene acceso                    |
 
 **Notas:**
-- Logística puede operar sobre turnos en estado "Con errores" y "Validado".
+- Logística puede ver todos los turnos sin importar su estado.
+- Solo puede editar turnos en estado "Con errores" y "Validado".
 - Puede corregir turnos con errores y crear/editar cupos y cargas, pero no eliminarlas.

--- a/src/utils/turnoEstadoPermisos.ts
+++ b/src/utils/turnoEstadoPermisos.ts
@@ -13,6 +13,16 @@ export const ESTADO_PERMISOS = [
 ];
 
 export function puedeVerEstado(estadoId: number, rolId: number): boolean {
+  // Logística (rolId: 4) puede ver todos los estados
+  if (rolId === 4) {
+    return true;
+  }
+  
+  const permiso = ESTADO_PERMISOS.find(e => e.id === estadoId);
+  return permiso ? permiso.roles.includes(rolId) : false;
+}
+
+export function puedeEditarEstado(estadoId: number, rolId: number): boolean {
   const permiso = ESTADO_PERMISOS.find(e => e.id === estadoId);
   return permiso ? permiso.roles.includes(rolId) : false;
 } 


### PR DESCRIPTION
- Logística puede ver todos los turnos sin importar estado
- Solo puede editar turnos en estados 'Con errores' y 'Validado'
- No hace llamadas adicionales a API de turnos (usa datos de cupos)
- Columnas específicas para logística: Nombre, Apellido, CUIL, CUIT, Razon Social, Patentes, Estado (no seleccionada por defecto)
- Actualizada documentación de permisos
- Mantiene funcionalidad existente para otros roles